### PR TITLE
CLI parameters parsing added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 extracted-data
 records
+
+.idea/

--- a/recorder.py
+++ b/recorder.py
@@ -17,9 +17,9 @@ LITERALS_NONE = "none"
 # Recording parameters that updated during script
 # gain???
 DEFAULT_PARAMS = {#keys '1', '2', etc. correspond to the written numbers sticked to camera bodies
-    '1' : {'ser_num' : '000583592412', 'master' : True , 'index' : None, 'sync_delay' : None, 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0, 'output_name' : None, 'timestamps_table_filename' : None},
-    '2' : {'ser_num' : '000905794612', 'master' : False, 'index' : None, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0, 'output_name' : None, 'timestamps_table_filename' : None},
-    '9' : {'ser_num' : '000489713912', 'master' : False, 'index' : None, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : -7, 'output_name' : None, 'timestamps_table_filename' : None}
+    '1' : {'ser_num' : '000583592412', 'master' : True, 'sync_delay' : None, 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0},
+    '2' : {'ser_num' : '000905794612', 'master' : False, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0},
+    '9' : {'ser_num' : '000489713912', 'master' : False, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : -7}
 }
 
 this_file_path = os.path.dirname(os.path.abspath(__file__))
@@ -122,8 +122,11 @@ def assign_indexes_to_predefined_cameras (connected_ser_nums, connected_indexes,
 
 # Prepare names for path and files
 # Params: master_cam_sticker, cams
-def create_names_for_path_and_files(cams, master_cam_sticker):
-    file_base_name = time.strftime("%Y-%m-%d-%H-%M-%S")
+def create_names_for_path_and_files(cams, master_cam_sticker, output_path=None):
+    if output_path is None:
+        file_base_name = time.strftime("%Y-%m-%d-%H-%M-%S")
+    else:
+        file_base_name = output_path
     master_name = f'{master_cam_sticker}m.mkv'#f'{file_base_name}-{master_cam_sticker}m.mkv'
     ts_table_filename = f'{master_cam_sticker}m.csv'
 
@@ -213,15 +216,13 @@ def main():
     argument_parser.add_argument("--stickers", type=str, required=False, nargs="+")
     argument_parser.add_argument("--ser_num", type=str, required=False, nargs="+")
     argument_parser.add_argument("--master", type=bool_or_str_type, required=False, nargs="+")
-    argument_parser.add_argument("--index", type=str, required=False, nargs="+")
     argument_parser.add_argument("--sync_delay", type=int_or_str_type, required=False, nargs="+")
     argument_parser.add_argument("--depth_delay", type=int_or_str_type, required=False, nargs="+")
     argument_parser.add_argument("--depth_mode", type=str, required=False, nargs="+")
     argument_parser.add_argument("--color_mode", type=str, required=False, nargs="+")
     argument_parser.add_argument("--frame_rate", type=int_or_str_type, required=False, nargs="+")
     argument_parser.add_argument("--exposure", type=int_or_str_type, required=False, nargs="+")
-    argument_parser.add_argument("--output_name", type=str, required=False, nargs="+")
-    argument_parser.add_argument("--timestamps_table_filename", type=str, required=False, nargs="+")
+    argument_parser.add_argument("--output_path", type=str, required=False)
     args = argument_parser.parse_args()
 
     cams = process_arguments(vars(args))
@@ -231,7 +232,7 @@ def main():
     connected_camera_list = subprocess.check_output([f'{executable}', '--list']).decode('utf-8') # Get connected camera list
     connected_ser_nums, connected_indexes = get_connected_camera_serial_numbers_and_indexes(connected_camera_list, predef_ser_nums)
     cams = assign_indexes_to_predefined_cameras (connected_ser_nums, connected_indexes, cams)
-    cams, file_base_name = create_names_for_path_and_files(cams, master_cam_sticker)
+    cams, file_base_name = create_names_for_path_and_files(cams, master_cam_sticker, args.output_path)
     master_cmd_line, subordinate_cmd_lines = prepare_recording_command_lines(cams, master_cam_sticker)
 
     # Create path

--- a/recorder.py
+++ b/recorder.py
@@ -17,9 +17,9 @@ LITERALS_NONE = "none"
 # Recording parameters that updated during script
 # gain???
 DEFAULT_PARAMS = {#keys '1', '2', etc. correspond to the written numbers sticked to camera bodies
-    '1' : {'ser_num' : '000583592412', 'master' : True, 'sync_delay' : None, 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0},
-    '2' : {'ser_num' : '000905794612', 'master' : False, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0},
-    '9' : {'ser_num' : '000489713912', 'master' : False, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : -7}
+    '1' : {'ser_num' : '000583592412', 'master' : True , 'index' : None, 'sync_delay' : None, 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0, 'output_name' : None, 'timestamps_table_filename' : None},
+    '2' : {'ser_num' : '000905794612', 'master' : False, 'index' : None, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : 0, 'output_name' : None, 'timestamps_table_filename' : None},
+    '9' : {'ser_num' : '000489713912', 'master' : False, 'index' : None, 'sync_delay' : 0   , 'depth_delay' : 0, 'depth_mode' : 'NFOV_UNBINNED', 'color_mode' : '720p', 'frame_rate' : 15, 'exposure' : -7, 'output_name' : None, 'timestamps_table_filename' : None}
 }
 
 this_file_path = os.path.dirname(os.path.abspath(__file__))
@@ -268,4 +268,3 @@ def main():
 
 if __name__ == '__main__':
     main()#sys.argv)
-


### PR DESCRIPTION
1. Comment these arguments since they do not change variables due to re-write during script:
--output_name 
--index
--timestamps_table_filename
Then change `process_argumants(...)` to avoid errors

2. Add argument `--output_path` to be able to create specific path in `records` folder. 
For instance, `--output_path hello-azures` will create output path 
`records/hello-azures` instead of
`records/2022-03-23-18-55-00`.