### PR TITLE
Dockerfile fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     curl \
     gpg-agent \
+    libboost-all-dev \
     libgl1-mesa-dev:$ARCH \
     libsoundio-dev:$ARCH \
     libjpeg-dev:$ARCH \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG ARCH=amd64
 
 ############ Part 2: SDK and multirecorder setup #############
 
-RUN apt-get update && apt-get install -y \
+RUN apt-get update --allow-unauthenticated && apt-get install -y --allow-unauthenticated \
     file \
     dpkg-dev \
     qemu \


### PR DESCRIPTION
The current version of the Dockerfile does not allow building the image:
```
-- Could NOT find Boost (missing: Boost_INCLUDE_DIR filesystem) 
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
Boost_INCLUDE_DIR (ADVANCED)
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder
   used as include directory in directory /multi-azure-recorder/Azure-Kinect-Sensor-SDK/tools/mrob_recorder

```

The solution is to add `libboost-all-dev` to the image